### PR TITLE
fix no such file or directory error during kubernetes installation on ubuntu

### DIFF
--- a/sopnode/ansible/roles/k8s/tasks/main_ubuntu.yaml
+++ b/sopnode/ansible/roles/k8s/tasks/main_ubuntu.yaml
@@ -11,7 +11,7 @@
 #    update_cache: true
 
 - name: quick fix
-  shell: curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.29/deb/Release.key |  gpg --batch --yes --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg ; echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.29/deb/ /' |  tee /etc/apt/sources.list.d/kubernetes.list; apt update -y
+  shell: mkdir -p /etc/apt/keyrings && curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.29/deb/Release.key |  gpg --batch --yes --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg ; echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.29/deb/ /' |  tee /etc/apt/sources.list.d/kubernetes.list; apt update -y
 
 - name: Install k8s tools
   ansible.builtin.apt:


### PR DESCRIPTION
A task in sopnode/ansible/roles/k8s/tasks/main_ubuntu.yaml fails when the directory /etc/apt/keyrings does not exist, because it attempts to write to /etc/apt/keyrings/kubernetes-apt-keyring.gpg. Ensuring that the directory exists beforehand fixes that.